### PR TITLE
[ch69081] Correct README key type

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ We've built a simple console application that demonstrates how LaunchDarkly's SD
 
 The sample application is built using [stack](https://docs.haskellstack.org/en/stable/README/).
 
-1. Copy your Mobile SDK key and feature flag key from your LaunchDarkly dashboard into `app/Main.hs`
+1. Copy your SDK key and feature flag key from your LaunchDarkly dashboard into `app/Main.hs`
 2. Run `stack build`
 3. Run `stack exec hello`


### PR DESCRIPTION
The haskell-server-sdk uses an SDK key not a mobile key.