### PR TITLE
additional comments for hello app

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -34,7 +34,7 @@ main :: IO ()
 main
   | sdkKey == "" = showMessage "Please edit Main.hs to set sdkKey to your LaunchDarkly SDK key first"
   | otherwise = do
-    let user = LD.makeUser "user@example.com" & LD.userSetName (Just "Sandy")
+    let user = LD.makeUser "example-user-key" & LD.userSetName (Just "Sandy")
     client <- LD.makeClient $ LD.makeConfig sdkKey
     initialized <- timeout (5_000 * 1_000) (waitForClient client)
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -34,6 +34,7 @@ main :: IO ()
 main
   | sdkKey == "" = showMessage "Please edit Main.hs to set sdkKey to your LaunchDarkly SDK key first"
   | otherwise = do
+     {- Set up the user properties. This user should appear on your LaunchDarkly users dashboard soon after you run the demo. -}
     let user = LD.makeUser "example-user-key" & LD.userSetName (Just "Sandy")
     client <- LD.makeClient $ LD.makeConfig sdkKey
     initialized <- timeout (5_000 * 1_000) (waitForClient client)
@@ -43,5 +44,6 @@ main
         showMessage "SDK successfully initialized!"
         launched <- LD.boolVariation client featureFlagKey user False
         showMessage $ printf "Feature flag '%s' is %s for this user." featureFlagKey (show launched)
+         {- Here we ensure that the SDK shuts down cleanly and has a chance to deliver analytics events to LaunchDarkly before the program exits. If analytics events are not delivered, the user properties and flag usage statistics will not appear on your dashboard. In a normal long-running application, the SDK would continue running and events would be delivered automatically in the background. -}
         LD.close client
       _ -> putStrLn "SDK failed to initialize"


### PR DESCRIPTION
Following up to #7 to finish bringing this in line with hello-app spec:

* use "example-user-key" as the user key (it's the standard value, and demonstrates not using PII in user keys)
* comments for the user creation and close calls. Let me know if there's a better way to format the multi-line comments.