### PR TITLE
chore: update Haskell server SDK from 4.5.1 to 4.6.0

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -4,4 +4,4 @@ packages:
 - .
 
 extra-deps:
-- launchdarkly-server-sdk-4.5.1
+- launchdarkly-server-sdk-4.6.0


### PR DESCRIPTION
## Summary

Update `launchdarkly-server-sdk` pin in `stack.yaml` from `4.5.1` → `4.6.0`. The 4.6.0 release adds the `X-LaunchDarkly-Instance-Id` header — no breaking changes.

Link to Devin session: https://app.devin.ai/sessions/093ea87681b74023a0a8f62e9c7e6d5a
Requested by: @kinyoklion